### PR TITLE
Migrating away from gulp-util

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,8 @@ debug.enable(debugName);
 debug = debug(debugName);
 
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
+var PluginError = require('plugin-error');
 var path = require('path');
 var fs = require('fs');
 var temp = require('temp');
@@ -25,8 +26,8 @@ var paths = {
 
 gulp.task('default', function(done) {
     Webpack().run(function(err, stats) {
-        if(err) throw new gutil.PluginError('webpack', err);
-        gutil.log('[webpack]', stats.toString({
+        if(err) throw new PluginError('webpack', err);
+        log('[webpack]', stats.toString({
             colors: true,
         }));
         done();

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "devDependencies": {
     "chalk": "^1.1.1",
     "debug": "^2.2.0",
+    "fancy-log": "^1.3.2",
     "gulp": "^3.9.1",
-    "gulp-util": "^3.0.7",
     "jshint": "^2.5.6",
     "json-loader": "^0.5.4",
+    "plugin-error": "^1.0.1"
     "progress-bar-webpack-plugin": "^1.6.0",
     "temp": "^0.8.3",
     "webpack": "^1.12.14",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp": "^3.9.1",
     "jshint": "^2.5.6",
     "json-loader": "^0.5.4",
-    "plugin-error": "^1.0.1"
+    "plugin-error": "^1.0.1",
     "progress-bar-webpack-plugin": "^1.6.0",
     "temp": "^0.8.3",
     "webpack": "^1.12.14",


### PR DESCRIPTION
Following changes suggested in https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 to avoid future issues with deprecated code from Gulp.